### PR TITLE
relo_core: members might be typedefs of anon structs

### DIFF
--- a/src/relo_core.c
+++ b/src/relo_core.c
@@ -1479,6 +1479,17 @@ static int btf_reloc_info_gen(struct btf_reloc_info *info, const struct bpf_core
 			continue;
 		}
 
+		if (btf_is_typedef(btf_type)) {
+			struct btf_type *typedef_type = btf_type_by_id(btf, btf_type->type);
+
+			if (!btf_is_struct(typedef_type) && !btf_is_union(typedef_type)) {
+				printf("typedef not a struct or an union: %u\n", btf_type->type);
+				return -1;
+			}
+
+			btf_type = typedef_type;
+		}
+
 		if (!btf_is_struct(btf_type) && !btf_is_union(btf_type)) {
 			printf("received a type not expected\n");
 			return -1;


### PR DESCRIPTION
Without this fix one may find the following error:

```
ibbpf: prog 'trace_commit_creds': relo #50: kind <byte_off> (0), spec is [10] struct task_struct.real_cred (0:105 @ offset 2856)
libbpf: prog 'trace_commit_creds': relo #50: matching candidate #0 [146] struct task_struct.real_cred (0:94 @ offset 2656)
libbpf: prog 'trace_commit_creds': relo #50: matching candidate #1 [28233] struct task_struct.real_cred (0:94 @ offset 2656)
libbpf: CO-RE relocating [0] struct cred: found target candidate [1741] struct cred in [vmlinux]
libbpf: CO-RE relocating [0] struct cred: found target candidate [28418] struct cred in [vmlinux]
libbpf: prog 'trace_commit_creds': relo #51: kind <byte_off> (0), spec is [621] struct cred.uid.val (0:1:0 @ offset 4)
libbpf: prog 'trace_commit_creds': relo #51: matching candidate #0 [1741] struct cred.uid.val (0:1:0 @ offset 4)
libbpf: prog 'trace_commit_creds': relo #51: matching candidate #1 [28418] struct cred.uid.val (0:1:0 @ offset 4)
received a type not expected
libbpf: error to generate BTF info
libbpf: prog 'trace_commit_creds': relo #51: failed to relocate: 1
failed to generate btf info for object
```

because btf_reloc_info_gen() wasn't considering the fact that a BTF_TYPE_STRUCT member might be a BTF_TYPE_TYPEDEF pointing to an anonymous BTF_TYPE_STRUCT (just like this case). 

With the change the issue is fixed.