### PR TITLE
Make struct reloc_info private

### DIFF
--- a/src/libbpf.c
+++ b/src/libbpf.c
@@ -5203,8 +5203,8 @@ bpf_object__relocate_core(struct bpf_object *obj,
 			pr_warn("failed to parse target BTF: %d\n", err);
 			return err;
 		}
-	} else if (obj->reloc_info && obj->reloc_info->src_btf) {
-		obj->btf_vmlinux_override = obj->reloc_info->src_btf;
+	} else if (obj->reloc_info && bpf_reloc_info_get_btf(obj->reloc_info)) {
+		obj->btf_vmlinux_override = bpf_reloc_info_get_btf(obj->reloc_info);
 	}
 
 	cand_cache = hashmap__new(bpf_core_hash_fn, bpf_core_equal_fn, NULL);

--- a/src/relo_core.h
+++ b/src/relo_core.h
@@ -88,18 +88,13 @@ struct bpf_core_cand_list {
 	int len;
 };
 
-struct btf_reloc_type;
-struct btf_reloc_ids_map;
+struct btf_reloc_info;
 
-struct btf_reloc_info {
-	struct btf_reloc_type *types, *types_last;
-	struct btf_reloc_ids_map *ids_map, *ids_map_last;
-
-	struct btf *src_btf;
-};
-
-struct btf_reloc_info *bpf_reloc_info_new(void);
+struct btf_reloc_info *bpf_reloc_info_new(const char *targ_btf_path);
 void bpf_reloc_info_free(struct btf_reloc_info *);
+void btf_reloc_info_dump(struct btf_reloc_info *info);
+int btf_reloc_info_save(struct btf_reloc_info *info, const char *path);
+struct btf *bpf_reloc_info_get_btf(struct btf_reloc_info *info);
 
 int bpf_core_apply_relo_insn(const char *prog_name,
 			     struct bpf_insn *insn, int insn_idx,
@@ -111,8 +106,5 @@ int bpf_core_types_are_compat(const struct btf *local_btf, __u32 local_id,
 			      const struct btf *targ_btf, __u32 targ_id);
 
 size_t bpf_core_essential_name_len(const char *name);
-
-void btf_reloc_info_dump(struct btf_reloc_info *info);
-int btf_reloc_info_save(struct btf_reloc_info *info, const char *path);
 
 #endif


### PR DESCRIPTION
- Move definition to c file
- Update bpf_reloc_info_new() to receive btf path
 