### PR TITLE
btf: make sure btf save path is closed on fwrite error

### DIFF
--- a/src/btf.c
+++ b/src/btf.c
@@ -4677,8 +4677,10 @@ int btf__save_to_file(struct btf *btf, const char *path) {
 	if (file == NULL)
 		return -1;
 
-	if (fwrite(data, 1, size, file) != size)
+	if (fwrite(data, 1, size, file) != size) {
+		fclose(file);
 		return -1;
+	}
 
 	if (fclose(file) != 0)
 		return -1;


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lorenzo.fontana@elastic.co>

# btf: make sure btf save path is closed on fwrite error.

If `fwrite` btf__save_to_file`  starts leaking file descriptors as shown here.

```
~ » ls  -la /proc/510001/fd
total 0
dr-x------ 2 fntlnz users  0 Oct  6 11:35 .
dr-xr-xr-x 9 fntlnz users  0 Oct  6 11:35 ..
lrwx------ 1 fntlnz users 64 Oct  6 11:35 0 -> /dev/pts/1
lrwx------ 1 fntlnz users 64 Oct  6 11:35 1 -> /dev/pts/1
lrwx------ 1 fntlnz users 64 Oct  6 11:35 2 -> /dev/pts/1
l-wx------ 1 fntlnz users 64 Oct  6 11:35 4 -> /tmp/btf/prefix-4.btf
l-wx------ 1 fntlnz users 64 Oct  6 11:35 5 -> /tmp/btf/prefix-3.btf
l-wx------ 1 fntlnz users 64 Oct  6 11:35 6 -> /tmp/btf/prefix-2.btf
l-wx------ 1 fntlnz users 64 Oct  6 11:35 7 -> /tmp/btf/prefix-vmlinux.btf
```

I tested this by using `btf__save_to_file` and by instrumenting `fwrite` return with ptrace in order to "fake" a write fail.

In a system where `btf__save_to_file` is used in a long running program this might become a problem.


As title says.

## How to use
Usage does not change

## Testing done

Same thing described above, in this case fds didn't leak.


