### PR TITLE
libbpf: move other operations to bpf_object__load()

### DIFF
--- a/src/libbpf.c
+++ b/src/libbpf.c
@@ -7371,10 +7371,6 @@ static int __bpf_object__prepare(struct bpf_object *obj, int log_level,
 		bpf_gen__init(obj->gen_loader, log_level);
 
 	err = bpf_object__load_vmlinux_btf(obj, false);
-	err = err ? : bpf_object__resolve_externs(obj, obj->kconfig);
-	err = err ? : bpf_object__sanitize_and_load_btf(obj);
-	err = err ? : bpf_object__sanitize_maps(obj);
-	err = err ? : bpf_object__init_kern_struct_ops_maps(obj);
 	err = err ? : bpf_object__relocate(obj, obj->btf_custom_path ? : target_btf_path);
 
 	obj->prepared = true;
@@ -7412,7 +7408,11 @@ int bpf_object__load_xattr(struct bpf_object_load_attr *attr)
 	}
 
 	err = bpf_object__probe_loading(obj);
-	err = err ? :bpf_object__create_maps(obj);
+	err = err ? : bpf_object__resolve_externs(obj, obj->kconfig);
+	err = err ? : bpf_object__sanitize_and_load_btf(obj);
+	err = err ? : bpf_object__sanitize_maps(obj);
+	err = err ? : bpf_object__init_kern_struct_ops_maps(obj);
+	err = err ? : bpf_object__create_maps(obj);
 	err = err ? : bpf_object__finish_relocate(obj);
 	err = err ? : bpf_object__load_progs(obj, attr->log_level);
 


### PR DESCRIPTION
There are some other operations that require privileges or depend in the
kernel we're running on. Let's move them to bpf_object__load instead.

Found while trying btfgen in a docker container:

Before:
```
./btfgen --input=../input/ --output=../output/ --obj=/ebpf/bcc/libbpf-tools/.output/bindsnoop.bpf.o
SBTF: ../input//5.4.0-88-generic.btf
OBJ : /ebpf/bcc/libbpf-tools/.output/bindsnoop.bpf.o
libbpf: Error in probe_kern_global_data():Operation not permitted(1). Couldn't create simple array map.
libbpf: Detection of kernel global variables support failed: -1
libbpf: kernel doesn't support global data
Segmentation fault (core dumped)
```

After:
```
./btfgen --input=../input/ --output=../output/ --obj=/ebpf/bcc/libbpf-tools/.output/bindsnoop.bpf.o
SBTF: ../input//5.4.0-88-generic.btf
OBJ : /ebpf/bcc/libbpf-tools/.output/bindsnoop.bpf.o
DBTF: ../output//5.4.0-88-generic.btf
STAT: done!
```